### PR TITLE
Add ability to invoke CoinbaseAccount with a known good oauth access token

### DIFF
--- a/coinbase/__init__.py
+++ b/coinbase/__init__.py
@@ -315,7 +315,7 @@ class CoinbaseAccount(object):
 
         return CoinbaseTransaction(response_parsed['transaction'])
 
-    def send(self, to_address, amount, notes='', currency='BTC'):
+    def send(self, to_address, amount, notes='', currency='BTC', transaction_params=dict()):
         """
         Send BitCoin from this account to either an email address or a BTC address
         :param to_address: Email or BTC address to where coin should be sent
@@ -345,11 +345,11 @@ class CoinbaseAccount(object):
                 }
             }
 
+        request_data['transaction'].update(transaction_params)
         response = self.session.post(url=url, data=json.dumps(request_data), params=self.global_request_params)
         response_parsed = response.json()
-
         if response_parsed['success'] == False:
-            raise RuntimeError('Transaction Failed')
+            raise RuntimeError('Transaction Failed: %s' % response_parsed.get('errors', 'no errors returned'))
 
         return CoinbaseTransaction(response_parsed['transaction'])
 

--- a/coinbase/models/transfer.py
+++ b/coinbase/models/transfer.py
@@ -18,7 +18,7 @@ class CoinbaseTransfer(object):
         self.fees_bank = CoinbaseAmount(fees_bank_cents, fees_bank_currency_iso)
 
         self.payout_date = transfer['payout_date']
-        self.transaction_id = transfer.get('transaction_id','')
+        self.transaction_id = transfer.get('id','')
         self.status = transfer['status']
 
         btc_amount = transfer['btc']['amount']


### PR DESCRIPTION
This pull request implements setting an arbitrary access_token for use when an oauth implementation whose data structures are not compatible with what the oauth2_credentials parameter expects.

In my testing I also ran into a situation when I was working with a string that was cast to unicode that produced an error when doing the 'type(<variable>) is str' test.  I modified the two instances of this (one in my new code and one in existing code) to check if the variables were instances of basestring instead.
