### PR TITLE
Include ca_certs.txt in distributions

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2,10 +2,13 @@
 README.txt
 setup.py
 coinbase/__init__.py
+coinbase/ca_certs.txt
 coinbase/config.py
 coinbase/tests.py
 coinbase/models/__init__.py
 coinbase/models/amount.py
 coinbase/models/contact.py
+coinbase/models/error.py
 coinbase/models/transaction.py
+coinbase/models/transfer.py
 coinbase/models/user.py

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name='coinbase',
     version='0.2.0',
     packages=['coinbase', 'coinbase.models'],
+    package_data={'coinbase': ['ca_certs.txt']},
     url='https://github.com/sibblegp/coinbase_python',
     license='MIT',
     author='George Sibble',


### PR DESCRIPTION
Right now distributions of coinbase_python don't include ca_cert.txt, leading to a broken installation. The issue this causes can be reproduced by creating a clean virtualenv, installing the coinbase library from pip, and trying to use functions that rely on the certificates.

Adding ca_certs.txt to package data fixes this.

I also included an updated copy of the MANIFEST file reflecting the change. It looks like some other files have been added to the project since the last time MANIFEST was generated too.
